### PR TITLE
ci: add enabledManagers and timezone setting in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "labels": ["renovate"],
+  "timezone": "Asia/Tokyo",
+  "enabledManagers": ["yarn"],
   "commitMessagePrefix": "chore(deps):",
   "platformAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added `timezone` configuration to use "Asia/Tokyo", ensuring Renovate runs are aligned with the specified timezone.
- Specified `enabledManagers` to "yarn", focusing Renovate's package updates to yarn managed packages.
- Improved readability of the `extends` configuration.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Enhance Renovate Configuration with Timezone and Enabled Managers</code></dd></summary>
<hr>

renovate.json
<li>Added <code>timezone</code> setting to specify the timezone as "Asia/Tokyo".<br> <li> Added <code>enabledManagers</code> with "yarn" to specify which package managers <br>Renovate should manage.<br> <li> Reformatted the <code>extends</code> array for better readability.


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/23/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

