### PR TITLE
ci: change rangeStrategy value to bump from auto in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "timezone": "Asia/Tokyo",
   "enabledManagers": ["yarn"],
   "commitMessagePrefix": "chore(deps):",
+  "rangeStrategy": "bump",
   "platformAutomerge": true,
   "packageRules": [
     {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated `renovate.json` to refine dependency update strategy by setting `rangeStrategy` to `bump`. This change aims to enhance the project's dependency management by explicitly defining the strategy for version updates.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Update Renovate Configuration for Dependency Management</code>&nbsp; &nbsp; </dd></summary>
<hr>

renovate.json
- Added `rangeStrategy` with the value `bump`.



</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/30/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

