### PR TITLE
chore(pr_agent.yml): add condition to skip the workflow if the actor is 'renovate[bot]' to avoid unnecessary runs

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -13,6 +13,7 @@ on:
       - edited
 jobs:
   pr_agent_job:
+    if: github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a condition in the GitHub Actions workflow (`pr_agent.yml`) to prevent execution when the PR is created by `renovate[bot]`, reducing unnecessary runs.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>Add Condition to Skip Workflow for `renovate[bot]`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml
<li>Added a condition to skip the workflow execution if the GitHub actor <br>is <code>renovate[bot]</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/58/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

