### PR TITLE
chore(renovate.json): update schedule to run Renovate checks every weekend instead of every Monday at 2am

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,5 @@
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 5,
-  "schedule": ["every monday at 2am"]
+  "schedule": ["every weekend"]
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the Renovate bot configuration to run checks every weekend instead of every Monday at 2am. This change aims to better align the update checks with the team's workflow.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Update Renovate Schedule Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json
<li>Changed the schedule for Renovate checks from "every Monday at 2am" to <br>"every weekend".


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/107/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

