### PR TITLE
feat(sprints.ts): add start and done methods to Sprints class to handle starting and completing sprints efficiently

### DIFF
--- a/backend/src/domain/project/sprints.ts
+++ b/backend/src/domain/project/sprints.ts
@@ -54,6 +54,32 @@ export class Sprints {
 		return O.some([new Sprints(newMap), sprint]);
 	}
 
+	start(
+		sprintId: SprintId,
+	): O.Option<[Sprints, Sprint]> {
+		const sprintOpt = this.findById(sprintId);
+		if (O.isNone(sprintOpt)) return O.none;
+		const sprint = sprintOpt.value;
+
+		const newSprint = sprint.withActive();
+		const newMap = new Map(this.values);
+		newMap.set(sprintId.value, newSprint);
+		return O.some([new Sprints(newMap), newSprint]);
+	}
+
+	done(
+		sprintId: SprintId,
+	): O.Option<[Sprints, Sprint]> {
+		const sprintOpt = this.findById(sprintId);
+		if (O.isNone(sprintOpt)) return O.none;
+		const sprint = sprintOpt.value;
+
+		const newSprint = sprint.withDone();
+		const newMap = new Map(this.values);
+		newMap.set(sprintId.value, newSprint);
+		return O.some([new Sprints(newMap), newSprint]);
+	}
+
 	findById(sprintId: SprintId): O.Option<Sprint> {
 		return O.fromNullable(this.values.get(sprintId.value));
 	}

--- a/backend/src/domain/project/sprints.ts
+++ b/backend/src/domain/project/sprints.ts
@@ -54,9 +54,7 @@ export class Sprints {
 		return O.some([new Sprints(newMap), sprint]);
 	}
 
-	start(
-		sprintId: SprintId,
-	): O.Option<[Sprints, Sprint]> {
+	start(sprintId: SprintId): O.Option<[Sprints, Sprint]> {
 		const sprintOpt = this.findById(sprintId);
 		if (O.isNone(sprintOpt)) return O.none;
 		const sprint = sprintOpt.value;
@@ -67,9 +65,7 @@ export class Sprints {
 		return O.some([new Sprints(newMap), newSprint]);
 	}
 
-	done(
-		sprintId: SprintId,
-	): O.Option<[Sprints, Sprint]> {
+	done(sprintId: SprintId): O.Option<[Sprints, Sprint]> {
 		const sprintOpt = this.findById(sprintId);
 		if (O.isNone(sprintOpt)) return O.none;
 		const sprint = sprintOpt.value;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced `start` and `done` methods in the `Sprints` class to manage sprint states.
- These methods allow setting a sprint's state to active or done, respectively, enhancing sprint lifecycle management.
- Added error handling to return `none` if the sprint does not exist.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sprints.ts</strong><dd><code>Implement Start and Done Methods for Sprint Management</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/domain/project/sprints.ts
<li>Added <code>start</code> method to initiate a sprint, setting its state to active.<br> <li> Added <code>done</code> method to complete a sprint, setting its state to done.<br> <li> Both methods check if the sprint exists before modifying its state.


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/122/files#diff-5f20e021eb612cfdd8d90db8b2613225d3bf000ff4437d88477a7fb439a74042">+26/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

