### PR TITLE
refactor(sprints.ts): change SprintId usage to improve type safety and consistency in Sprints class

### DIFF
--- a/backend/src/domain/project/sprints.ts
+++ b/backend/src/domain/project/sprints.ts
@@ -83,7 +83,7 @@ export class Sprints {
 			return false;
 		}
 		for (const [key, value] of values) {
-			const otherValue = this.values.get(key);
+			const otherValue = other.toMap().get(key);
 			if (otherValue === undefined || !value.equals(otherValue)) {
 				return false;
 			}

--- a/backend/src/domain/project/sprints.ts
+++ b/backend/src/domain/project/sprints.ts
@@ -79,11 +79,12 @@ export class Sprints {
 
 	equals(other: Sprints): boolean {
 		const values = this.toMap();
-		if (values.size !== other.values.size) {
+		const otherValues = other.toMap();
+		if (values.size !== otherValues.size) {
 			return false;
 		}
 		for (const [key, value] of values) {
-			const otherValue = other.toMap().get(key);
+			const otherValue = otherValues.get(key);
 			if (otherValue === undefined || !value.equals(otherValue)) {
 				return false;
 			}

--- a/backend/src/domain/project/sprints.ts
+++ b/backend/src/domain/project/sprints.ts
@@ -1,13 +1,13 @@
 import * as O from "fp-ts/lib/Option";
 import type { Sprint } from "./sprint";
-import { SprintId } from "./sprint-id";
+import type { SprintId } from "./sprint-id";
 
-const SprintsTypeSymbol = Symbol("Srpints");
+const SprintsTypeSymbol = Symbol("Sprints");
 
 export class Sprints {
 	readonly symbol: typeof SprintsTypeSymbol = SprintsTypeSymbol;
 
-	private constructor(readonly values: Map<string, Sprint>) {
+	private constructor(readonly values: Map<SprintId, Sprint>) {
 		const activeSprintCount = Array.from(values.values()).filter((sprint) =>
 			sprint.isActive(),
 		).length;
@@ -21,36 +21,29 @@ export class Sprints {
 	}
 
 	static ofSingle(sprint: Sprint): Sprints {
-		return new Sprints(new Map([[sprint.id.value, sprint]]));
+		return new Sprints(new Map([[sprint.id, sprint]]));
 	}
 
 	static fromArray(values: Sprint[]): Sprints {
-		return new Sprints(new Map(values.map((m) => [m.id.value, m])));
+		return new Sprints(new Map(values.map((m) => [m.id, m])));
 	}
 
 	static fromMap(values: Map<SprintId, Sprint>): Sprints {
-		return new Sprints(
-			new Map(
-				Array.from(values.entries()).map(([sprintId, member]) => [
-					sprintId.value,
-					member,
-				]),
-			),
-		);
+		return new Sprints(values);
 	}
 
 	add(sprint: Sprint): Sprints {
 		if (this.containsById(sprint.id)) {
 			throw new Error("Sprint already exists");
 		}
-		return new Sprints(new Map(this.values).set(sprint.id.value, sprint));
+		return new Sprints(new Map(this.values).set(sprint.id, sprint));
 	}
 
 	edit(sprint: Sprint): O.Option<[Sprints, Sprint]> {
 		if (!this.containsById(sprint.id)) return O.none;
 
 		const newMap = new Map(this.values);
-		newMap.set(sprint.id.value, sprint);
+		newMap.set(sprint.id, sprint);
 		return O.some([new Sprints(newMap), sprint]);
 	}
 
@@ -61,7 +54,7 @@ export class Sprints {
 
 		const newSprint = sprint.withActive();
 		const newMap = new Map(this.values);
-		newMap.set(sprintId.value, newSprint);
+		newMap.set(sprintId, newSprint);
 		return O.some([new Sprints(newMap), newSprint]);
 	}
 
@@ -72,16 +65,16 @@ export class Sprints {
 
 		const newSprint = sprint.withDone();
 		const newMap = new Map(this.values);
-		newMap.set(sprintId.value, newSprint);
+		newMap.set(sprintId, newSprint);
 		return O.some([new Sprints(newMap), newSprint]);
 	}
 
 	findById(sprintId: SprintId): O.Option<Sprint> {
-		return O.fromNullable(this.values.get(sprintId.value));
+		return O.fromNullable(this.values.get(sprintId));
 	}
 
 	containsById(sprintId: SprintId): boolean {
-		return this.values.has(sprintId.value);
+		return this.values.has(sprintId);
 	}
 
 	equals(other: Sprints): boolean {
@@ -90,7 +83,7 @@ export class Sprints {
 			return false;
 		}
 		for (const [key, value] of values) {
-			const otherValue = this.values.get(key.value);
+			const otherValue = this.values.get(key);
 			if (otherValue === undefined || !value.equals(otherValue)) {
 				return false;
 			}
@@ -103,12 +96,7 @@ export class Sprints {
 	}
 
 	toMap(): Map<SprintId, Sprint> {
-		return new Map(
-			Array.from(this.values.entries()).map(([key, value]) => [
-				SprintId.of(key),
-				value,
-			]),
-		);
+		return this.values;
 	}
 
 	toJSON(): Record<string, unknown> {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced type safety by changing the key type of the `Map` in the `Sprints` class from `string` to `SprintId`.
- Fixed a typo in the declaration of `SprintsTypeSymbol`.
- Simplified the implementation of `fromMap` and `toMap` methods to directly use the passed or existing map.
- Updated all relevant methods to utilize `SprintId` directly, improving code consistency and reducing errors.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sprints.ts</strong><dd><code>Enhance Type Safety and Simplify Map Usage in Sprints Class</code></dd></summary>
<hr>

backend/src/domain/project/sprints.ts
<li>Changed the type of keys in the <code>Map</code> from <code>string</code> to <code>SprintId</code> for type <br>safety.<br> <li> Corrected a typo in the symbol name from "Srpints" to "Sprints".<br> <li> Simplified the <code>fromMap</code> and <code>toMap</code> methods by using the map directly <br>instead of transforming it.<br> <li> Updated all methods to use <code>SprintId</code> directly instead of <br><code>sprintId.value</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/127/files#diff-5f20e021eb612cfdd8d90db8b2613225d3bf000ff4437d88477a7fb439a74042">+14/-26</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

