### PR TITLE
feat(project.ts): introduce SprintNotExistError class to handle cases where a sprint does not exist in the project and update editSprint, startSprint, and completeSprint methods to return an Either with SprintNotExistError instead of throwing an Error

### DIFF
--- a/backend/src/domain/project/project.ts
+++ b/backend/src/domain/project/project.ts
@@ -1,7 +1,7 @@
 import type { Aggregate } from "event-store-adapter-js";
-import { pipe } from "fp-ts/lib/function";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
 import type { AccountId } from "../account/account-id";
 import { SprintNotExistError } from "./errors/project-errors";
 import {


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced `SprintNotExistError` class to handle cases where a sprint does not exist in the project.
- Updated `editSprint`, `startSprint`, and `completeSprint` methods in `Project` class to return an `Either` with `SprintNotExistError` instead of throwing an error.
- Replaced thrown errors with `Either.left` containing `SprintNotExistError` in the mentioned methods.
- Modified error handling in event processing methods to use the new `SprintNotExistError` class.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.ts</strong><dd><code>Introduce `SprintNotExistError` and update sprint methods to use it.</code></dd></summary>
<hr>

backend/src/domain/project/project.ts
<li>Introduced <code>SprintNotExistError</code> class to handle non-existent sprints.<br> <li> Updated <code>editSprint</code>, <code>startSprint</code>, and <code>completeSprint</code> methods to return <br><code>Either</code> with <code>SprintNotExistError</code>.<br> <li> Replaced thrown errors with <code>Either.left</code> containing <br><code>SprintNotExistError</code>.<br> <li> Modified error handling in event processing methods to use the new <br>error class.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/158/files#diff-8e9b39f77ed5711b2c6346b1655e53a2eb2d2556ccb865fb87bad690beb8ce4c">+14/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

