### PR TITLE
feat(project-errors.ts): add MemberNotFoundError class to handle cases where a member is not found in a project

### DIFF
--- a/backend/src/domain/project/errors/project-errors.ts
+++ b/backend/src/domain/project/errors/project-errors.ts
@@ -1,3 +1,4 @@
+import type { AccountId } from "../../account/account-id";
 import type { DomainError } from "../../shared/domain-error";
 import type { ProjectId } from "../project-id";
 import type { SprintId } from "../sprint-id";
@@ -26,5 +27,21 @@ export class SprintNotExistError implements DomainError {
 		sprintId: SprintId;
 	}): SprintNotExistError {
 		return new SprintNotExistError(detail);
+	}
+}
+
+export class MemberNotFoundError implements DomainError {
+	readonly symbol = Symbol("MemberNotFoundError");
+	readonly message = "The member was not found.";
+
+	private constructor(
+		readonly detail: { projectId: ProjectId; accountId: AccountId },
+	) {}
+
+	static of(detail: {
+		projectId: ProjectId;
+		accountId: AccountId;
+	}): MemberNotFoundError {
+		return new MemberNotFoundError(detail);
 	}
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `MemberNotFoundError` class to handle cases where a member is not found in a project.
- Updated `removeMember` and `changeMemberRole` methods in the `Project` class to return `MemberNotFoundError` if the member is not found.
- Improved error handling by replacing error throwing with `Either` type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project-errors.ts</strong><dd><code>Add `MemberNotFoundError` class for member not found scenarios.</code></dd></summary>
<hr>

backend/src/domain/project/errors/project-errors.ts
<li>Added <code>MemberNotFoundError</code> class to handle cases where a member is not <br>found in a project.<br> <li> Implemented a static method <code>of</code> for creating instances of <br><code>MemberNotFoundError</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/171/files#diff-05b8a769969969c4c7b90ac4ee3546b85e14f5064d3a0ffb73dd37adbc4a1b3e">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>project.ts</strong><dd><code>Update `Project` methods to handle `MemberNotFoundError`.</code></dd></summary>
<hr>

backend/src/domain/project/project.ts
<li>Updated <code>removeMember</code> method to return <code>MemberNotFoundError</code> if the <br>member is not found.<br> <li> Updated <code>changeMemberRole</code> method to return <code>MemberNotFoundError</code> if the <br>member is not found.<br> <li> Removed error throwing and replaced with <code>Either</code> type for better error <br>handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/171/files#diff-8e9b39f77ed5711b2c6346b1655e53a2eb2d2556ccb865fb87bad690beb8ce4c">+13/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

