### PR TITLE
fix(workspace.ts): throw an error when trying to apply WorkspaceCreated event to prevent unintended behavior

### DIFF
--- a/backend/src/domain/workspace/workspace.ts
+++ b/backend/src/domain/workspace/workspace.ts
@@ -59,7 +59,7 @@ export class Workspace implements Aggregate<Workspace, WorkspaceId> {
 	private applyEvent(event: WorkspaceEvent): Workspace {
 		switch (event.symbol) {
 			case WorkspaceCreatedTypeSymbol:
-				return this;
+				throw new Error("WorkspaceCreated event should not be applied");
 		}
 	}
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Throw an error when attempting to apply the `WorkspaceCreated` event in the `Workspace` class to prevent unintended behavior.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.ts</strong><dd><code>Prevent applying `WorkspaceCreated` event by throwing an error</code></dd></summary>
<hr>

backend/src/domain/workspace/workspace.ts

- Throw an error when `WorkspaceCreated` event is applied.



</details>


  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/185/files#diff-2b75f8cfdb45223df8f484dab915d7878c831a7a218f746883a9f956a06a829b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

