### PR TITLE
fix(renovate.json): update renovate configuration to prevent automerge of major updates to devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,8 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "automerge": true
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     },
     {
       "matchPackagePatterns": ["serverless"],


### PR DESCRIPTION
### **User description**
…


___

### **PR Type**
configuration changes


___

### **Description**
- Updated the Renovate configuration to prevent automerging of major updates to devDependencies.
- Added a new `matchUpdateTypes` field with value `major` to the devDependencies section.
- Set `automerge` to false for major updates to devDependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Prevent automerge of major updates to devDependencies in Renovate </code><br><code>configuration</code></dd></summary>
<hr>

renovate.json

<li>Added <code>matchUpdateTypes</code> with value <code>major</code> to the devDependencies <br>section.<br> <li> Set <code>automerge</code> to false for major updates to devDependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/190/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

