### PR TITLE
chore(renovate.json): update renovate configuration to use matchPackageNames instead of excludePackageNames for @aws-sdk/client-dynamodb to improve clarity and consistency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,9 +23,7 @@
       "enabled": false
     },
     {
-      "excludePackageNames": [
-        "@aws-sdk/client-dynamodb"
-      ],
+      "matchPackageNames": ["@aws-sdk/client-dynamodb"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
### **User description**
…


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated Renovate configuration to use `matchPackageNames` instead of `excludePackageNames` for `@aws-sdk/client-dynamodb`.
- Improved clarity and consistency in the Renovate configuration file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Update Renovate configuration for package matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<li>Replaced <code>excludePackageNames</code> with <code>matchPackageNames</code> for <br><code>@aws-sdk/client-dynamodb</code>.<br> <li> Improved clarity and consistency in Renovate configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/kooooichi24/event-sourcing-example-ts/pull/212/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

